### PR TITLE
Improved form validation

### DIFF
--- a/lib/src/core/field_controller_base.dart
+++ b/lib/src/core/field_controller_base.dart
@@ -92,5 +92,6 @@ abstract class _FieldControllerBase<T extends Object> extends ChangeNotifier {
     _lastErrorValue = null;
     _isSubmitted = false;
     _error = InputFieldError.none();
+    notifyListeners();
   }
 }

--- a/lib/src/core/form_controller.dart
+++ b/lib/src/core/form_controller.dart
@@ -43,8 +43,8 @@ class FormController extends _FormControllerBase with Diagnosticable {
   }
 
   @override
-  bool validate({Set<Object>? tags, bool notify = true}) {
-    final fields = (tags ?? _activeTags).map(call);
+  bool validate({Set<Object>? tagsToValidate, bool notify = true}) {
+    final fields = (tagsToValidate ?? tags).map(call);
 
     var isFormValid = true;
     for (final field in fields) {

--- a/lib/src/core/form_controller_base.dart
+++ b/lib/src/core/form_controller_base.dart
@@ -76,7 +76,7 @@ abstract class _FormControllerBase extends ChangeNotifier {
   /// only the fields with the given [tags] will be validated.
   /// If [notify] is true,
   /// the form will notify its listeners if the form is invalid.
-  bool validate({Set<Object>? tags, bool notify = true});
+  bool validate({Set<Object>? tagsToValidate, bool notify = true});
 
   /// Sets the field bound with the [tag] as active.
   void activate(Object tag);


### PR DESCRIPTION
formController.validate() method only validates the controllers bound to UI in current viewport (i.e validates only the activeTags). To enforce validation of all the controllers that are inside/outside the viewport must be validated with formController.validate(tags: allTagsThatMustBeValidated)

But I guess it would be more concise to allow all the controllers with tags bound to the FormController for Validation by default if no params is passed in formController.validate().

ℹ️Possible enhancement
`lib\src\core\form_controller.dart`

````dart
@override
  bool validate({Set<Object>? tagsToValidate, bool notify = true}) {
    final fields = (tagsToValidate ?? tags).map(call);

    var isFormValid = true;
    for (final field in fields) {
      if (!field.validate(notify: notify)) isFormValid = false;
    }

    _setValidity(isValid: isFormValid);
    if (!isFormValid) notifyListeners();
    return isFormValid;
  }
