### PR TITLE
fix issue resetting controller programmatically

### DIFF
--- a/lib/src/core/field_controller_base.dart
+++ b/lib/src/core/field_controller_base.dart
@@ -92,5 +92,6 @@ abstract class _FieldControllerBase<T extends Object> extends ChangeNotifier {
     _lastErrorValue = null;
     _isSubmitted = false;
     _error = InputFieldError.none();
+    notifyListeners();
   }
 }


### PR DESCRIPTION
# ISSUE

- formController.reset() removes the value from controller but does not notify listeners about the value change.

# PR CHANGES

- Adds line to notify listeners about the change in value of controller  and hence act accordingly.